### PR TITLE
make war executable

### DIFF
--- a/spring-boot-app/pom.xml
+++ b/spring-boot-app/pom.xml
@@ -61,11 +61,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <warSourceDirectory>WebContent</warSourceDirectory>
-                </configuration>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
According to these fine spring boot docker articles:

 - https://stackify.com/guide-docker-java/
 - https://stackify.com/spring-boot-level-up/

the war file in the spring-boot-app module should be executable but it is not:

$ java -jar target/spring-boot-app-0.0.1-SNAPSHOT.war
no main manifest attribute, in target/spring-boot-app-0.0.1-SNAPSHOT.war
